### PR TITLE
低解像度出力時の不具合を修正

### DIFF
--- a/Assets/VFXTextureMaker/Editor/TextureData.cs
+++ b/Assets/VFXTextureMaker/Editor/TextureData.cs
@@ -145,7 +145,7 @@ namespace VFXTextureMaker
         RenderTexture _resultRT;
         RenderTexture _bufferRT;
         RenderTexture _seetRT;
-        const int ThreadCount = 32;
+        const int ThreadCount = 1;
         readonly int ResolutionID = Shader.PropertyToID("_Resolution");
         readonly int ResultID = Shader.PropertyToID("_Result");
         readonly int BufferID = Shader.PropertyToID("_Buffer");

--- a/Assets/VFXTextureMaker/EditorResources/Shaders/TextureSeet.compute
+++ b/Assets/VFXTextureMaker/EditorResources/Shaders/TextureSeet.compute
@@ -8,7 +8,7 @@ float2 _SeetCount;
 float2 _DrawSize;
 int _Index;
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Clear(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -16,7 +16,7 @@ void Clear(uint3 id : SV_DispatchThreadID)
     _Result[ids.xy] = float4(0, 0, 0, 0);
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void CsMain(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));

--- a/Assets/VFXTextureMaker/EditorResources/Shaders/VFXTextureMaker.compute
+++ b/Assets/VFXTextureMaker/EditorResources/Shaders/VFXTextureMaker.compute
@@ -52,7 +52,7 @@ float4 _DrawColor;
 #include "OpColorBalance.cginc"
 
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Clear(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -60,7 +60,7 @@ void Clear(uint3 id : SV_DispatchThreadID)
     _Result[ids] = float4(0, 0, 0, 0);
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Draw(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -79,7 +79,7 @@ void Draw_Draw(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Displacement(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -89,7 +89,7 @@ void Displacement_Displacement(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Texture(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -108,7 +108,7 @@ void Draw_Texture(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Texture(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -119,7 +119,7 @@ void Displacement_Texture(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_NormalMap(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -131,7 +131,7 @@ void Displacement_NormalMap(uint3 id : SV_DispatchThreadID)
 }
 
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Noise_ValueNoise(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -151,7 +151,7 @@ void Draw_Noise_ValueNoise(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Noise_ValueNoiseGrad(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -170,7 +170,7 @@ void Draw_Noise_ValueNoiseGrad(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Noise_PerlinNoise(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -189,7 +189,7 @@ void Draw_Noise_PerlinNoise(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Noise_PerlinNoiseGrad(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -208,7 +208,7 @@ void Draw_Noise_PerlinNoiseGrad(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Noise_DistanceNoise(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -227,7 +227,7 @@ void Draw_Noise_DistanceNoise(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Noise_Voronoi(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -246,7 +246,7 @@ void Draw_Noise_Voronoi(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Noise_VoronoiEdge(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -265,7 +265,7 @@ void Draw_Noise_VoronoiEdge(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Noise_ValueNoise(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -276,7 +276,7 @@ void Displacement_Noise_ValueNoise(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Noise_ValueNoiseGrad(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -287,7 +287,7 @@ void Displacement_Noise_ValueNoiseGrad(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Noise_PerlinNoise(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -298,7 +298,7 @@ void Displacement_Noise_PerlinNoise(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Noise_PerlinNoiseGrad(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -309,7 +309,7 @@ void Displacement_Noise_PerlinNoiseGrad(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Noise_DistanceNoise(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -320,7 +320,7 @@ void Displacement_Noise_DistanceNoise(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Noise_Voronoi(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -331,7 +331,7 @@ void Displacement_Noise_Voronoi(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Displacement_Noise_VoronoiEdge(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -342,7 +342,7 @@ void Displacement_Noise_VoronoiEdge(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Shape_DistancePower(uint2 id : SV_DispatchThreadID)
 {
 
@@ -362,7 +362,7 @@ void Draw_Shape_DistancePower(uint2 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Draw_Shape_Polygon(uint2 id : SV_DispatchThreadID)
 {
 
@@ -382,7 +382,7 @@ void Draw_Shape_Polygon(uint2 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Filter_Blur_Gausian(uint2 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -393,7 +393,7 @@ void Filter_Blur_Gausian(uint2 id : SV_DispatchThreadID)
     _Result[id] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Filter_Blur_Direction(uint2 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -404,7 +404,7 @@ void Filter_Blur_Direction(uint2 id : SV_DispatchThreadID)
     _Result[id] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Filter_Blur_Zoom(uint2 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -415,7 +415,7 @@ void Filter_Blur_Zoom(uint2 id : SV_DispatchThreadID)
     _Result[id] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Filter_Blur_Rotate(uint2 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -426,7 +426,7 @@ void Filter_Blur_Rotate(uint2 id : SV_DispatchThreadID)
     _Result[id] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Filter_GradationSample(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -445,7 +445,7 @@ void Filter_GradationSample(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Filter_Glow(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));
@@ -464,7 +464,7 @@ void Filter_Glow(uint3 id : SV_DispatchThreadID)
     _Result[ids] = col;
 }
 
-[numthreads(32, 32, 1)]
+[numthreads(1, 1, 1)]
 void Filter_ColorBalance(uint3 id : SV_DispatchThreadID)
 {
     int2 ids = int2(asint(id.x), asint(id.y));


### PR DESCRIPTION
- 低解像度でSpriteSheet書き出しを行うと配置が崩れる不具合を修正
　→NumThreadを１に変更